### PR TITLE
refactor: tweak naming conventions/mem management and add new type

### DIFF
--- a/include/components.h
+++ b/include/components.h
@@ -36,3 +36,16 @@ typedef struct SpriteAnimation
     Rectangle *rectangles;
     int rectanglesLength;
 } SpriteAnimation;
+
+/**
+ * Container for various player animations
+ */
+typedef struct
+{
+    SpriteAnimation right;
+    SpriteAnimation left;
+    SpriteAnimation up;
+    SpriteAnimation down;
+    SpriteAnimation idle;
+    SpriteAnimation *current;
+} PlayerAnimations;

--- a/include/components.h
+++ b/include/components.h
@@ -29,7 +29,7 @@ typedef struct
 typedef struct SpriteAnimation
 {
     Texture2D atlas;
-    Texture2D curremtFrame;
+    Texture2D currentFrame;
     int framesPerSecond;
     float timeStarted;
 

--- a/include/player.h
+++ b/include/player.h
@@ -19,10 +19,11 @@ typedef struct
     float size;              ///< Size of the player collision box
     Rectangle collision_box; ///< Calculated collision box
     Sprite sprite;
+    Texture2D sprite_sheet; ///< Sprite sheet texture for animations
 } Player;
 
-void UpdatePlayerDrawFrame(Vector2 positionw);
-void CreatePlayerSpriteAnimation(void);
+void update_player_draw_frame(Vector2 positionw);
+void create_player_sprite_animation(void);
 void _player_move(void);
 void _player_draw(void);
-void DrawDebugInfo(void);
+void draw_debug_info(void);

--- a/include/spritesheet_reader.h
+++ b/include/spritesheet_reader.h
@@ -3,9 +3,10 @@
 #include "components.h"
 #include <raylib.h>
 
-SpriteAnimation CreateSpriteAnimation(Texture2D atlas, int framesPerSecond, Rectangle rectangles[],
-                                      int length);
-void DisposeSpriteAnimation(SpriteAnimation animation);
-void DrawSpriteAnimationPro(SpriteAnimation animation, Rectangle dest, Vector2 origin,
-                            float rotation, Color tint, float scale);
-Texture2D GetSpriteAnimationCurrentFrame(const SpriteAnimation *animation, Rectangle *outSource);
+SpriteAnimation create_sprite_animation(Texture2D atlas, int framesPerSecond,
+                                        Rectangle rectangles[], int length);
+void dispose_sprite_animation(SpriteAnimation animation);
+void draw_sprite_animation_pro(SpriteAnimation animation, Rectangle dest, Vector2 origin,
+                               float rotation, Color tint, float scale);
+Texture2D get_sprite_animation_current_frame(const SpriteAnimation *animation,
+                                             Rectangle *outSource);

--- a/src/game.c
+++ b/src/game.c
@@ -59,8 +59,7 @@ static void _game_input_handler(void)
 
 void game_init(void)
 {
-    // CreatePlayerSpriteAnimation();
-    CreatePlayerSpriteAnimation();
+    create_player_sprite_animation();
 
     const char *file_path = "assets/map.csv";
     Result res = map_load_from_csv(file_path);
@@ -77,7 +76,6 @@ void game_init(void)
     Game_ctx.player.velocity.max_speed = Game_cfg.player_base_speed;
     Game_ctx.player.size = Game_cfg.player_size;
 
-    Game_ctx.player.sprite.texture = LoadTexture("assets/sample-assets/Texture/player-cropped.png");
     Game_ctx.player.sprite.rotation = 0.0f;
     Game_ctx.player.sprite.tint = WHITE;
     Game_ctx.player.sprite.scale = 1.0f;

--- a/src/player.c
+++ b/src/player.c
@@ -7,56 +7,57 @@
 #include <raylib.h>
 #include <raymath.h>
 
-SpriteAnimation _walk_right_animation;
-SpriteAnimation _walk_left_animation;
-SpriteAnimation _walk_up_animation;
-SpriteAnimation _walk_down_animation;
-SpriteAnimation _idle_animation;
-SpriteAnimation _animation = {0};
+PlayerAnimations anims = {};
+// SpriteAnimation _walk_right_animation;
+// SpriteAnimation _walk_left_animation;
+// SpriteAnimation _walk_up_animation;
+// SpriteAnimation _walk_down_animation;
+// SpriteAnimation _idle_animation;
+SpriteAnimation curr_animation = {0};
 
 void create_player_sprite_animation(void)
 {
     Game_ctx.player.sprite_sheet = LoadTexture("assets/sample-assets/Texture/mario.png");
-    _idle_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 1,
-                                              (Rectangle[]){
-                                                  (Rectangle){32, 0, 32, 32},
-                                              },
-                                              1);
-    _walk_right_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
-                                                    (Rectangle[]){
-                                                        (Rectangle){0, 96, 32, 32},
-                                                        (Rectangle){32, 96, 32, 32},
-                                                        (Rectangle){64, 96, 32, 32},
-                                                    },
-                                                    2);
-    _walk_left_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
-                                                   (Rectangle[]){
-                                                       (Rectangle){0, 64, 32, 32},
-                                                       (Rectangle){32, 64, 32, 32},
-                                                       (Rectangle){64, 64, 32, 32},
-                                                   },
-                                                   2);
-    _walk_up_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
-                                                 (Rectangle[]){
-                                                     (Rectangle){0, 32, 32, 32},
-                                                     (Rectangle){32, 32, 32, 32},
-                                                     (Rectangle){64, 32, 32, 32},
-                                                 },
-                                                 3);
-    _walk_down_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
-                                                   (Rectangle[]){
-                                                       (Rectangle){0, 0, 32, 32},
-                                                       (Rectangle){32, 0, 32, 32},
-                                                       (Rectangle){64, 0, 32, 32},
-                                                   },
-                                                   3);
+    anims.idle = create_sprite_animation(Game_ctx.player.sprite_sheet, 1,
+                                         (Rectangle[]){
+                                             (Rectangle){32, 0, 32, 32},
+                                         },
+                                         1);
+    anims.right = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                          (Rectangle[]){
+                                              (Rectangle){0, 96, 32, 32},
+                                              (Rectangle){32, 96, 32, 32},
+                                              (Rectangle){64, 96, 32, 32},
+                                          },
+                                          2);
+    anims.left = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                         (Rectangle[]){
+                                             (Rectangle){0, 64, 32, 32},
+                                             (Rectangle){32, 64, 32, 32},
+                                             (Rectangle){64, 64, 32, 32},
+                                         },
+                                         2);
+    anims.up = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                       (Rectangle[]){
+                                           (Rectangle){0, 32, 32, 32},
+                                           (Rectangle){32, 32, 32, 32},
+                                           (Rectangle){64, 32, 32, 32},
+                                       },
+                                       3);
+    anims.down = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                         (Rectangle[]){
+                                             (Rectangle){0, 0, 32, 32},
+                                             (Rectangle){32, 0, 32, 32},
+                                             (Rectangle){64, 0, 32, 32},
+                                         },
+                                         3);
 }
 
 void update_player_draw_frame(Vector2 positionw)
 {
     // Get current frame source rect and atlas
     Rectangle src;
-    Texture2D atlas = get_sprite_animation_current_frame(&_animation, &src);
+    Texture2D atlas = get_sprite_animation_current_frame(&curr_animation, &src);
     if (atlas.id == 0)
         return; // nothing to draw
 
@@ -131,26 +132,26 @@ void _player_move(void)
     if (IsKeyDown(KEY_W))
     {
         move_vector.y -= 1.0f;
-        _animation = _walk_up_animation;
+        curr_animation = anims.up;
     }
 
     if (IsKeyDown(KEY_S))
     {
         move_vector.y += 1.0f;
-        _animation = _walk_down_animation;
+        curr_animation = anims.down;
     }
 
     if (IsKeyDown(KEY_A))
     {
         move_vector.x -= 1.0f;
-        _animation = _walk_left_animation;
+        curr_animation = anims.left;
     }
 
     if (IsKeyDown(KEY_D))
     {
 
         move_vector.x += 1.0f;
-        _animation = _walk_right_animation;
+        curr_animation = anims.right;
     }
 
     if (Vector2Length(move_vector) > 0.0f)
@@ -189,7 +190,7 @@ void _player_move(void)
     {
         // No movement input, so velocity is zero
         Game_ctx.player.velocity.vec = (Vector2){0};
-        _animation = _idle_animation;
+        curr_animation = anims.idle;
     }
 
     // Camera always follows the player's position

--- a/src/player.c
+++ b/src/player.c
@@ -7,7 +7,6 @@
 #include <raylib.h>
 #include <raymath.h>
 
-Texture2D _player_sprite_sheet;
 SpriteAnimation _walk_right_animation;
 SpriteAnimation _walk_left_animation;
 SpriteAnimation _walk_up_animation;
@@ -15,49 +14,49 @@ SpriteAnimation _walk_down_animation;
 SpriteAnimation _idle_animation;
 SpriteAnimation _animation = {0};
 
-void CreatePlayerSpriteAnimation(void)
+void create_player_sprite_animation(void)
 {
-    _player_sprite_sheet = LoadTexture("assets/sample-assets/Texture/mario.png");
-    _idle_animation = CreateSpriteAnimation(_player_sprite_sheet, 1,
-                                            (Rectangle[]){
-                                                (Rectangle){32, 0, 32, 32},
-                                            },
-                                            1);
-    _walk_right_animation = CreateSpriteAnimation(_player_sprite_sheet, 6,
-                                                  (Rectangle[]){
-                                                      (Rectangle){0, 96, 32, 32},
-                                                      (Rectangle){32, 96, 32, 32},
-                                                      (Rectangle){64, 96, 32, 32},
-                                                  },
-                                                  2);
-    _walk_left_animation = CreateSpriteAnimation(_player_sprite_sheet, 6,
+    Game_ctx.player.sprite_sheet = LoadTexture("assets/sample-assets/Texture/mario.png");
+    _idle_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 1,
+                                              (Rectangle[]){
+                                                  (Rectangle){32, 0, 32, 32},
+                                              },
+                                              1);
+    _walk_right_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                                    (Rectangle[]){
+                                                        (Rectangle){0, 96, 32, 32},
+                                                        (Rectangle){32, 96, 32, 32},
+                                                        (Rectangle){64, 96, 32, 32},
+                                                    },
+                                                    2);
+    _walk_left_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                                   (Rectangle[]){
+                                                       (Rectangle){0, 64, 32, 32},
+                                                       (Rectangle){32, 64, 32, 32},
+                                                       (Rectangle){64, 64, 32, 32},
+                                                   },
+                                                   2);
+    _walk_up_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
                                                  (Rectangle[]){
-                                                     (Rectangle){0, 64, 32, 32},
-                                                     (Rectangle){32, 64, 32, 32},
-                                                     (Rectangle){64, 64, 32, 32},
-                                                 },
-                                                 2);
-    _walk_up_animation = CreateSpriteAnimation(_player_sprite_sheet, 6,
-                                               (Rectangle[]){
-                                                   (Rectangle){0, 32, 32, 32},
-                                                   (Rectangle){32, 32, 32, 32},
-                                                   (Rectangle){64, 32, 32, 32},
-                                               },
-                                               3);
-    _walk_down_animation = CreateSpriteAnimation(_player_sprite_sheet, 6,
-                                                 (Rectangle[]){
-                                                     (Rectangle){0, 0, 32, 32},
-                                                     (Rectangle){32, 0, 32, 32},
-                                                     (Rectangle){64, 0, 32, 32},
+                                                     (Rectangle){0, 32, 32, 32},
+                                                     (Rectangle){32, 32, 32, 32},
+                                                     (Rectangle){64, 32, 32, 32},
                                                  },
                                                  3);
+    _walk_down_animation = create_sprite_animation(Game_ctx.player.sprite_sheet, 6,
+                                                   (Rectangle[]){
+                                                       (Rectangle){0, 0, 32, 32},
+                                                       (Rectangle){32, 0, 32, 32},
+                                                       (Rectangle){64, 0, 32, 32},
+                                                   },
+                                                   3);
 }
 
-void UpdatePlayerDrawFrame(Vector2 positionw)
+void update_player_draw_frame(Vector2 positionw)
 {
     // Get current frame source rect and atlas
     Rectangle src;
-    Texture2D atlas = GetSpriteAnimationCurrentFrame(&_animation, &src);
+    Texture2D atlas = get_sprite_animation_current_frame(&_animation, &src);
     if (atlas.id == 0)
         return; // nothing to draw
 
@@ -83,7 +82,7 @@ void _player_draw(void)
 
     };
 
-    UpdatePlayerDrawFrame(Vector2Add(Game_ctx.player.position, sprite_center));
+    update_player_draw_frame(Vector2Add(Game_ctx.player.position, sprite_center));
 
     /*DrawTextureEx(Game_ctx.player.sprite.texture, Vector2Subtract(Game_ctx.player.position,
        sprite_center), Game_ctx.player.sprite.rotation, Game_ctx.player.sprite.scale,
@@ -91,7 +90,7 @@ void _player_draw(void)
                    */
 
 #ifdef DEBUG
-    DrawDebugInfo();
+    draw_debug_info();
     DrawLine((int)Game_ctx.camera.target.x, -GetScreenHeight() * 10, (int)Game_ctx.camera.target.x,
              GetScreenHeight() * 10, ORANGE);
     // DrawLine(-GetScreenWidth() * 10, (int)Game_ctx.camera.target.y, GetScreenWidth() * 10,
@@ -100,7 +99,7 @@ void _player_draw(void)
 #endif
 }
 
-void DrawDebugInfo(void)
+void draw_debug_info(void)
 {
     // Get camera and player position as strings
     char playerPosText[64];

--- a/src/player.c
+++ b/src/player.c
@@ -13,7 +13,7 @@ PlayerAnimations anims = {};
 // SpriteAnimation _walk_up_animation;
 // SpriteAnimation _walk_down_animation;
 // SpriteAnimation _idle_animation;
-SpriteAnimation curr_animation = {0};
+// SpriteAnimation curr_animation = {0};
 
 void create_player_sprite_animation(void)
 {
@@ -57,7 +57,7 @@ void update_player_draw_frame(Vector2 positionw)
 {
     // Get current frame source rect and atlas
     Rectangle src;
-    Texture2D atlas = get_sprite_animation_current_frame(&curr_animation, &src);
+    Texture2D atlas = get_sprite_animation_current_frame(anims.current, &src);
     if (atlas.id == 0)
         return; // nothing to draw
 
@@ -132,26 +132,26 @@ void _player_move(void)
     if (IsKeyDown(KEY_W))
     {
         move_vector.y -= 1.0f;
-        curr_animation = anims.up;
+        anims.current = &anims.up;
     }
 
     if (IsKeyDown(KEY_S))
     {
         move_vector.y += 1.0f;
-        curr_animation = anims.down;
+        anims.current = &anims.down;
     }
 
     if (IsKeyDown(KEY_A))
     {
         move_vector.x -= 1.0f;
-        curr_animation = anims.left;
+        anims.current = &anims.left;
     }
 
     if (IsKeyDown(KEY_D))
     {
 
         move_vector.x += 1.0f;
-        curr_animation = anims.right;
+        anims.current = &anims.right;
     }
 
     if (Vector2Length(move_vector) > 0.0f)
@@ -190,7 +190,7 @@ void _player_move(void)
     {
         // No movement input, so velocity is zero
         Game_ctx.player.velocity.vec = (Vector2){0};
-        curr_animation = anims.idle;
+        anims.current = &anims.idle;
     }
 
     // Camera always follows the player's position

--- a/src/player.c
+++ b/src/player.c
@@ -8,12 +8,6 @@
 #include <raymath.h>
 
 PlayerAnimations anims = {};
-// SpriteAnimation _walk_right_animation;
-// SpriteAnimation _walk_left_animation;
-// SpriteAnimation _walk_up_animation;
-// SpriteAnimation _walk_down_animation;
-// SpriteAnimation _idle_animation;
-// SpriteAnimation curr_animation = {0};
 
 void create_player_sprite_animation(void)
 {

--- a/src/spritesheet_reader.c
+++ b/src/spritesheet_reader.c
@@ -1,9 +1,10 @@
 #include "spritesheet_reader.h"
 #include "raylib.h"
+#include "utils.h"
 #include <stdlib.h>
 
-SpriteAnimation CreateSpriteAnimation(Texture2D atlas, int framesPerSecond, Rectangle rectangles[],
-                                      int length)
+SpriteAnimation create_sprite_animation(Texture2D atlas, int framesPerSecond,
+                                        Rectangle rectangles[], int length)
 {
     SpriteAnimation spriteAnimation = {.atlas = atlas,
                                        .framesPerSecond = framesPerSecond,
@@ -11,10 +12,10 @@ SpriteAnimation CreateSpriteAnimation(Texture2D atlas, int framesPerSecond, Rect
                                        .rectangles = NULL,
                                        .rectanglesLength = length};
 
-    Rectangle *mem = (Rectangle *)malloc(sizeof(Rectangle) * length);
+    Rectangle *mem = (Rectangle *)heap_list.malloc(sizeof(Rectangle) * length);
     if (mem == NULL)
     {
-        TraceLog(LOG_FATAL, "No memory for CreateSpriteAnimation");
+        TraceLog(LOG_FATAL, "No memory for create_sprite_animation");
         spriteAnimation.rectanglesLength = 0;
         return spriteAnimation;
     }
@@ -29,10 +30,10 @@ SpriteAnimation CreateSpriteAnimation(Texture2D atlas, int framesPerSecond, Rect
     return spriteAnimation;
 }
 
-void DisposeSpriteAnimation(SpriteAnimation animation) { free(animation.rectangles); }
+void dispose_sprite_animation(SpriteAnimation animation) { heap_list.free(animation.rectangles); }
 
-void DrawSpriteAnimationPro(SpriteAnimation animation, Rectangle dest, Vector2 origin,
-                            float rotation, Color tint, float scale)
+void draw_sprite_animation_pro(SpriteAnimation animation, Rectangle dest, Vector2 origin,
+                               float rotation, Color tint, float scale)
 {
     int index = (int)((GetTime() - animation.timeStarted) * animation.framesPerSecond) %
                 animation.rectanglesLength;
@@ -41,7 +42,7 @@ void DrawSpriteAnimationPro(SpriteAnimation animation, Rectangle dest, Vector2 o
 
     DrawTexturePro(animation.atlas, source, dest, origin, rotation, tint);
 }
-Texture2D GetSpriteAnimationCurrentFrame(const SpriteAnimation *animation, Rectangle *outSource)
+Texture2D get_sprite_animation_current_frame(const SpriteAnimation *animation, Rectangle *outSource)
 {
     if (animation == NULL || animation->rectanglesLength == 0 || animation->rectangles == NULL)
     {


### PR DESCRIPTION
- Move player sprite_sheet from file-static to Player struct
- Remove unused texture loading in game.c
- Fix naming conventions: use snake_case for functions
  - CreatePlayerSpriteAnimation -> create_player_sprite_animation
  - UpdatePlayerDrawFrame -> update_player_draw_frame
  - DrawDebugInfo -> draw_debug_info
  - CreateSpriteAnimation -> create_sprite_animation
  - DisposeSpriteAnimation -> dispose_sprite_animation
  - DrawSpriteAnimationPro -> draw_sprite_animation_pro
  - GetSpriteAnimationCurrentFrame -> get_sprite_animation_current_frame
- Replace malloc/free with heap_list.malloc/free in spritesheet_reader.c
- Fix typo: curremtFrame -> currentFrame in components.h
- Create and use `PlayerAnimations` container type in `player.c` (purely organizational, but might slightly improve performance due to use of a pointer type to keep track of the current animation)